### PR TITLE
Remove redundant update instructions from install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,5 +103,3 @@ fi
 echo ""
 echo -e "${GREEN}✨ Installation complete!${NC}"
 echo ""
-echo "To update your configuration later, run:"
-echo -e "  ${BLUE}curl -fsSL https://raw.githubusercontent.com/${GITHUB_USER}/${REPO_NAME}/${BRANCH}/install.sh | bash${NC}"


### PR DESCRIPTION
## Summary
• Remove duplicate installation command from install.sh output
• Installation instructions are now properly documented in README

## Test plan
- [x] Verify install script runs without redundant output
- [x] Confirm README contains installation instructions

🤖 Generated with [Claude Code](https://claude.ai/code)