### PR TITLE
Add support for .claude/agents directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,7 @@ echo -e "${BLUE}📋 Installing Claude configuration...${NC}"
 # Create ~/.claude directory if it doesn't exist
 mkdir -p "$HOME/.claude"
 mkdir -p "$HOME/.claude/commands"
+mkdir -p "$HOME/.claude/agents"
 
 # Function to copy file
 copy_file() {
@@ -98,6 +99,18 @@ if [ -d "$DOTFILES_DIR/.claude/commands" ]; then
     done
 else
     echo -e "${YELLOW}⚠️  No commands directory found in repository${NC}"
+fi
+
+# Copy agent files
+if [ -d "$DOTFILES_DIR/.claude/agents" ]; then
+    for agent_file in "$DOTFILES_DIR/.claude/agents"/*.md; do
+        if [ -f "$agent_file" ]; then
+            filename=$(basename "$agent_file")
+            copy_file "$agent_file" "$HOME/.claude/agents/$filename"
+        fi
+    done
+else
+    echo -e "${YELLOW}⚠️  No agents directory found in repository${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Added support for copying `.claude/agents` directory during installation
- Install script now creates `~/.claude/agents` directory
- Agent files (*.md) are copied from the repository to the local configuration

## Test plan
- [ ] Run install.sh and verify ~/.claude/agents directory is created
- [ ] Place test agent files in .claude/agents/ and verify they are copied
- [ ] Verify warning message appears when agents directory is not found

🤖 Generated with [Claude Code](https://claude.ai/code)